### PR TITLE
Fixes to conform to MLA standards

### DIFF
--- a/mla13.sty
+++ b/mla13.sty
@@ -78,16 +78,16 @@
 
 %End Bibliography Commands
 %remove parenthesis from bibliography
-\renewbibmacro*{issue+date}{%
-  \setunit{\addcomma\space}% NEW
+%\renewbibmacro*{issue+date}{%
+%  \setunit{\addcomma\space}% NEW
 %  \printtext[parens]{% DELETED
-    \iffieldundef{issue}
-      {\usebibmacro{date}}
-      {\printfield{issue}%
-       \setunit*{\addspace}%
+%    \iffieldundef{issue}
+%      {\usebibmacro{date}}
+%      {\printfield{issue}%
+%       \setunit*{\addspace}%
 %       \usebibmacro{date}}}% DELETED
-       \usebibmacro{date}}% NEW
-  \newunit}
+%       \usebibmacro{date}}% NEW
+%  \newunit}
 %end section
 
 \geometry{top=1.0in,bottom=1.0in,left=1.0in,right=1.0in}


### PR DESCRIPTION
MLA format requires that the hanging indent of citations be 0.5in. This is not the default in biblatex-mla. This commit sets \bibhang appropriately.

Also, commit https://github.com/kc9jud/mla13/commit/b6187f5255258e132678d6ad5dac43c8cc64efd2 fixes the missing parentheses as discussed in https://github.com/jmclawson/biblatex-mla/issues/5
