### PR TITLE
Simplify indentation

### DIFF
--- a/mla13.sty
+++ b/mla13.sty
@@ -6,6 +6,7 @@
 \usepackage[american]{babel}
 \usepackage{csquotes}
 \usepackage{setspace}
+\setlength{\parindent}{0.5in}
 \usepackage[style=mla,mladraft=true,annotation=true]{biblatex}
 \usepackage{color}
 \newcommand{\sources}[1]{
@@ -110,8 +111,6 @@
 }
 \pagestyle{empty}
 \pagestyle{fancy}
-\setlength{\parindent}{0.5in}
-\setlength{\bibhang}{\parindent}
 \fancyhf{}
 \fancyhead{}
 \renewcommand{\headrulewidth}{0pt}


### PR DESCRIPTION
Fixing while avoiding redefining the `\bibhang` length by setting the `\parindent` length before calling the `biblatex` package.
